### PR TITLE
ActivityManager: fix perf boost NPE

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -3619,7 +3619,7 @@ public final class ActivityManagerService extends ActivityManagerNative
             StringBuilder buf = mStringBuilder;
             buf.setLength(0);
             if (hostingType.equals("activity")) {
-                mPerf.launchBoost(startResult.pid, app.processName);
+                launchBoost(startResult.pid, app.processName);
             }
             buf.append("Start proc ");
             buf.append(startResult.pid);


### PR DESCRIPTION
Able to get an NPE by factory resetting a device, and then just
rebooting it.

Change-Id: I6f5bbcf59dc20a75a209d6d70e6c3e35fff01406
Signed-off-by: Roman Birg roman@cyngn.com
