### PR TITLE
Fix incorrect behavior for statusbar and quicksettings panel

### DIFF
--- a/services/core/java/com/android/server/statusbar/StatusBarManagerService.java
+++ b/services/core/java/com/android/server/statusbar/StatusBarManagerService.java
@@ -249,7 +249,7 @@ public class StatusBarManagerService extends IStatusBarService.Stub {
      */
     @Override
     public void disable2(int what, IBinder token, String pkg) {
-        disableForUser(what, token, pkg, mCurrentUserId);
+        disable2ForUser(what, token, pkg, mCurrentUserId);
     }
 
     /**


### PR DESCRIPTION
Incorrectly disableForUser() is called in disable2().
Use disable2ForUser() instead of disableForUser().

Bug: 27688623
Change-Id: Iadb6aec82ccfe95a90e4a3d212fbd14d73093982
